### PR TITLE
endpoint instead of db for connection caching

### DIFF
--- a/syngenta_digital_dta/postgres/sql_connection.py
+++ b/syngenta_digital_dta/postgres/sql_connection.py
@@ -9,10 +9,10 @@ def sql_connection(func: typing.Callable) -> typing.Callable:
     def decorator(obj: typing.Union["PostgresAdapter", "RedshiftAdapter"]):
 
         # reuse the existing connection if it isn't closed
-        if __connections.get(obj.database) and __connections[obj.database].connection and not __connections[obj.database].connection.closed:
-            return func(obj, __connections[obj.database])
+        if __connections.get(obj.endpoint) and __connections[obj.endpoint].connection and not __connections[obj.endpoint].connection.closed:
+            return func(obj, __connections[obj.endpoint])
 
-        __connections[obj.database] = SQLConnector(obj)
-        return func(obj, __connections[obj.database])
+        __connections[obj.endpoint] = SQLConnector(obj)
+        return func(obj, __connections[obj.endpoint])
 
     return decorator


### PR DESCRIPTION
This changes the value we use for connection caching to endpoint so we can have simaltaneous connections to the same database using different endpoints, for example a writer and reader endpoint.

Currently, because this caches on the database, a second connection attempt to that database would end up just reusing the existing connection. In this specific example we want 2 database connections open.