### PR TITLE
use public url instead of presigned url when passing between lambdas

### DIFF
--- a/syngenta_digital_dta/s3/adapter.py
+++ b/syngenta_digital_dta/s3/adapter.py
@@ -237,4 +237,4 @@ class S3Adapter(BaseAdapter):
         return 'private'
 
     def __generate_publish_data(self, **kwargs):
-        return {'presigned_url': self.create_presigned_read_url(**kwargs)}
+        return {'presigned_url': self.create_public_url(**kwargs)}


### PR DESCRIPTION
> Lambda assumes the execution role associated with your function to fetch temporary security credentials which are then available as environment variables during a function's invocation. If you use these temporary credentials outside of Lambda, such as to create a presigned Amazon S3 URL, you can't control the session duration. The IAM maximum session duration setting doesn't apply to sessions that are assumed by AWS services such as Lambda. Use the sts:AssumeRole action if you need control over session duration.

[Lambda execution role - AWS Lambda (amazon.com)](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html#permissions-executionrole-session)

In short - presigned read urls expire when the execution role temporary token does, regardless of the expiry time of the presigned url. If messages will sit in your SQS queues for longer than an hour, you either need to deliberately assume a role using STS assume role, or not use a presigned url.