### PR TITLE
dont require postgres packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,10 @@ setup(
     packages=find_packages(),
     python_requires='>=3.0',
     install_requires=[
-        'aws-psycopg2',
         'boto3',
         'elasticsearch==7.13.4',
         'jsonref',
         'jsonpickle',
-        'psycopg2-binary',
         'pyyaml',
         'requests-aws4auth',
         'simplejson'


### PR DESCRIPTION
AWS lambda has an unzipped size limit of 250MB - we need to be very careful about the size of our dependency chains. Most teams don't use postgres for integrations, so we shouldnt require that these packages are installed for the DTA. 